### PR TITLE
Improve Errors given when lookups for models fail

### DIFF
--- a/src/csrs/crud/__init__.py
+++ b/src/csrs/crud/__init__.py
@@ -1,1 +1,3 @@
 from . import assumptions, metric_values, metrics, paths, runs, scenarios, timeseries
+
+__all__ = [assumptions, metric_values, metrics, paths, runs, scenarios, timeseries]

--- a/src/csrs/crud/assumptions.py
+++ b/src/csrs/crud/assumptions.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
-from ..errors import DuplicateModelError
+from ..errors import DuplicateModelError, EmptyLookupError
 from ..logger import logger
 from ._common import common_update, rollback_on_exception
 
@@ -52,6 +52,8 @@ def read(
     if kind:
         filters.append(models.Assumption.kind == kind)
     results = db.query(models.Assumption).filter(*filters).all()
+    if len(results) == 0:
+        raise EmptyLookupError(models.Assumption, name=name, kind=kind, id=id)
     return [schemas.Assumption.model_validate(m, from_attributes=True) for m in results]
 
 

--- a/src/csrs/crud/assumptions.py
+++ b/src/csrs/crud/assumptions.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
-from ..errors import DuplicateAssumptionError
+from ..errors import DuplicateModelError
 from ..logger import logger
 from ._common import common_update, rollback_on_exception
 
@@ -28,7 +28,7 @@ def create(
         if dup_detail:
             dup_detail = detail
         logger.error(f"error adding assumption, {dup_name=}, {dup_detail=}")
-        raise DuplicateAssumptionError(dup_name, dup_detail)
+        raise DuplicateModelError(models.Assumption, name=dup_name, detail=dup_detail)
     model = models.Assumption(name=name, kind=kind, detail=detail)
     db.add(model)
     db.commit()

--- a/src/csrs/crud/paths.py
+++ b/src/csrs/crud/paths.py
@@ -1,6 +1,7 @@
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
+from ..errors import EmptyLookupError
 from ..logger import logger
 from ._common import common_update, rollback_on_exception
 from .runs import read as read_runs
@@ -55,6 +56,14 @@ def read(
     if id:
         filters.append(models.NamedPath.id == id)
     paths = db.query(models.NamedPath).filter(*filters).all()
+    if len(paths) == 0:
+        raise EmptyLookupError(
+            models.NamedPath,
+            name=name,
+            path=str(path),
+            category=category,
+            id=id,
+        )
     return [schemas.NamedPath.model_validate(p, from_attributes=True) for p in paths]
 
 

--- a/src/csrs/crud/runs.py
+++ b/src/csrs/crud/runs.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
-from ..errors import LookupUniqueError
+from ..errors import UniqueLookupError
 from ..logger import logger
 from . import timeseries as crud_timeseries
 from ._common import common_update, rollback_on_exception
@@ -143,7 +143,7 @@ def update(
     logger.info(f"updating run where {id=}")
     obj = db.query(models.Run).where(models.Run.id == id).first()
     if not obj:
-        raise LookupUniqueError(models.Run, obj, id=id)
+        raise UniqueLookupError(models.Run, obj, id=id)
     # All supported updates on Run are simple setattr actions,
     # so we will just use the common_update func using args that were not None
     updates = dict(  # make sure this dict uses all the args above
@@ -184,7 +184,7 @@ def delete(
                 version=ts.version,
                 path=ts.path,
             )
-        except LookupUniqueError:
+        except UniqueLookupError:
             logger.warning(
                 "when deleting a Timeseries while  deleting a Run, "
                 + "the following Timeseries wasn't found, but the delete action "

--- a/src/csrs/crud/runs.py
+++ b/src/csrs/crud/runs.py
@@ -102,6 +102,7 @@ def create_run_history(
     return hist
 
 
+@rollback_on_exception
 def read(
     db: Session,
     scenario: str = None,
@@ -162,6 +163,7 @@ def update(
     return model_to_schema(obj)
 
 
+@rollback_on_exception
 def delete(
     db: Session,
     id: int,

--- a/src/csrs/crud/scenarios.py
+++ b/src/csrs/crud/scenarios.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
-from ..errors import DuplicateScenarioError, LookupUniqueError
+from ..errors import DuplicateModelError, UniqueLookupError
 from ..logger import logger
 from . import assumptions as crud_assumptions
 from . import runs as crud_runs
@@ -37,13 +37,13 @@ def create(
     dup_name = db.query(models.Scenario).filter_by(name=name).first() is not None
     if dup_name:
         logger.error(f"{dup_name=}")
-        raise DuplicateScenarioError(name)
+        raise DuplicateModelError(models.Scenario, name=dup_name)
     scenario_assumptions = dict()
     for a_kind, a_name in assumptions.items():
         assumption_model = crud_assumptions.read(db, kind=a_kind, name=a_name)
         if len(assumption_model) != 1:
             logger.error("more than one assumption corresponds")
-            raise LookupUniqueError(
+            raise UniqueLookupError(
                 models.Assumption,
                 assumption_model,
                 table_name=a_kind,
@@ -107,7 +107,7 @@ def _update_preferred_run(db: Session, id: int, preferred_run: str) -> models.Sc
         .first()
     )
     if not run:  # Specied Run not found
-        raise LookupUniqueError(
+        raise UniqueLookupError(
             models.Run,
             run,
             version=preferred_run,
@@ -141,7 +141,7 @@ def _update_assumptions(
         logger.debug(f"setting {kind} to {name}")
         assumption_obj = crud_assumptions.read(db, kind=kind, name=name)
         if len(assumption_obj) != 1:
-            raise LookupUniqueError(
+            raise UniqueLookupError(
                 models.Assumption,
                 assumption_obj,
                 kind=kind,
@@ -179,7 +179,7 @@ def update(
 ) -> schemas.Scenario:
     obj = db.query(models.Scenario).filter(models.Scenario.id == id).first()
     if not obj:
-        raise LookupUniqueError(models.Scenario, obj, id=id)
+        raise UniqueLookupError(models.Scenario, obj, id=id)
     if name:
         _update_name(db, id, name)
     if preferred_run:

--- a/src/csrs/crud/scenarios.py
+++ b/src/csrs/crud/scenarios.py
@@ -192,6 +192,7 @@ def update(
     return model_to_schema(obj)
 
 
+@rollback_on_exception
 def delete(
     db: Session,
     id: int,

--- a/src/csrs/crud/timeseries.py
+++ b/src/csrs/crud/timeseries.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from .. import models, schemas
 from ..database import EPOCH
-from ..errors import LookupUniqueError
+from ..errors import UniqueLookupError
 from ..logger import logger
 from . import paths as crud_paths
 from ._common import rollback_on_exception
@@ -48,7 +48,7 @@ def get_run_model(db: Session, scenario: str, version: str) -> models.Run:
     )
     runs = [r for r in runs if r.version == version]
     if len(runs) != 1:  # Couldn't find version
-        raise LookupUniqueError(models.Run, runs, version=version, scenario=scenario)
+        raise UniqueLookupError(models.Run, runs, version=version, scenario=scenario)
     return runs[0]
 
 
@@ -91,7 +91,7 @@ def create(
     if not path_schemas:
         path_schemas = crud_paths.read(db=db, name=path)
     if len(path_schemas) != 1:
-        raise LookupUniqueError(models.NamedPath, path_schemas, path=repr(path))
+        raise UniqueLookupError(models.NamedPath, path_schemas, path=repr(path))
     dss_path = path_schemas[0].path
     path_model = (
         db.query(models.NamedPath).filter(models.NamedPath.path == dss_path).first()
@@ -148,7 +148,7 @@ def read(
     if not path_schemas:
         path_schemas = crud_paths.read(db=db, name=path)
     if len(path_schemas) != 1:
-        raise LookupUniqueError(models.NamedPath, path_schemas, path=repr(path))
+        raise UniqueLookupError(models.NamedPath, path_schemas, path=repr(path))
     path_schema = path_schemas[0]
     # Get data from database
     rows = (
@@ -246,7 +246,7 @@ def delete(db: Session, scenario: str, version: str, path: str) -> int:
     )
     objs = statement.all()
     if not objs:
-        raise LookupUniqueError(
+        raise UniqueLookupError(
             models.TimeseriesLedger,
             objs,
             sceanrio=scenario,

--- a/src/csrs/crud/timeseries.py
+++ b/src/csrs/crud/timeseries.py
@@ -234,6 +234,7 @@ def update():
     raise NotImplementedError()
 
 
+@rollback_on_exception
 def delete(db: Session, scenario: str, version: str, path: str) -> int:
     statement = (
         db.query(models.TimeseriesLedger)

--- a/src/csrs/crud/timeseries.py
+++ b/src/csrs/crud/timeseries.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from .. import models, schemas
 from ..database import EPOCH
-from ..errors import UniqueLookupError
+from ..errors import EmptyLookupError, UniqueLookupError
 from ..logger import logger
 from . import paths as crud_paths
 from ._common import rollback_on_exception
@@ -38,6 +38,7 @@ def get_dss_root(db: Session) -> Path:
 
 
 def get_run_model(db: Session, scenario: str, version: str) -> models.Run:
+    # TODO: 2024-07-30 See if we can remove this function in favor of crud.runs.read
     if not isinstance(scenario, str):
         raise ValueError(f"{scenario=}, expected str")
     scenario_model = (
@@ -47,8 +48,8 @@ def get_run_model(db: Session, scenario: str, version: str) -> models.Run:
         db.query(models.Run).filter(models.Run.scenario_id == scenario_model.id).all()
     )
     runs = [r for r in runs if r.version == version]
-    if len(runs) != 1:  # Couldn't find version
-        raise UniqueLookupError(models.Run, runs, version=version, scenario=scenario)
+    if len(runs) == 0:  # Couldn't find version
+        raise EmptyLookupError(models.Run, version=version, scenario=scenario)
     return runs[0]
 
 
@@ -90,7 +91,7 @@ def create(
     path_schemas = crud_paths.read(db=db, path=path)
     if not path_schemas:
         path_schemas = crud_paths.read(db=db, name=path)
-    if len(path_schemas) != 1:
+    if len(path_schemas) > 1:
         raise UniqueLookupError(models.NamedPath, path_schemas, path=repr(path))
     dss_path = path_schemas[0].path
     path_model = (
@@ -147,8 +148,8 @@ def read(
     path_schemas = crud_paths.read(db=db, path=path)
     if not path_schemas:
         path_schemas = crud_paths.read(db=db, name=path)
-    if len(path_schemas) != 1:
-        raise UniqueLookupError(models.NamedPath, path_schemas, path=repr(path))
+    if len(path_schemas) == 0:
+        raise EmptyLookupError(models.NamedPath, path=repr(path))
     path_schema = path_schemas[0]
     # Get data from database
     rows = (
@@ -246,10 +247,9 @@ def delete(db: Session, scenario: str, version: str, path: str) -> int:
         .where(models.NamedPath.path == path)
     )
     objs = statement.all()
-    if not objs:
-        raise UniqueLookupError(
+    if len(objs) == 0:
+        raise EmptyLookupError(
             models.TimeseriesLedger,
-            objs,
             sceanrio=scenario,
             version=version,
             path=path,

--- a/src/csrs/errors.py
+++ b/src/csrs/errors.py
@@ -22,3 +22,14 @@ class UniqueLookupError(Exception):
             error_message = error_message + "\nthe objects were:" + "\n\t".join(objects)
 
         super().__init__(error_message)
+
+
+class EmptyLookupError(Exception):
+    def __init__(self, model: Base, **filters):
+        error_message = (
+            f"0 {model.__name__} were found when at least 1 was expected,\n"
+            + " filters were:\n\t"
+            + "\n\t".join(f"{k}: {v}" for k, v in filters.items())
+        )
+
+        super().__init__(error_message)

--- a/src/csrs/errors.py
+++ b/src/csrs/errors.py
@@ -1,37 +1,24 @@
 from typing import Iterable
 
+from .models import Base
 
-class DuplicateAssumptionError(Exception):
-    def __init__(self, on_name: bool, on_detail: bool):
-        super().__init__(
-            "assumption given is a duplicate,\n"
-            + f"\tduplicate name={on_name},\n"
-            + f"\tduplicate detail={on_detail}."
+
+class DuplicateModelError(Exception):
+    def __init__(self, model: Base, **duplicate_fields: dict[str, str]):
+        error_message = f"{model=} already exists where:\n\t" + "\n\t".join(
+            f"{k}: {v}" for k, v in duplicate_fields.items()
         )
+        super().__init__(error_message)
 
 
-class DuplicateScenarioError(Exception):
-    def __init__(self, name: str):
-        super().__init__("scenario given is a duplicate,\n\tduplicate {name=}.")
-
-
-class LookupUniqueError(Exception):
-    def __init__(self, model, returned, **filters):
-        if hasattr(returned, "__iter__"):
-            returned = len(returned)
-
-        super().__init__(
-            f"couldn't find unique entry in {model} table for filters given,\n"
-            + f"\titems found: {returned}\n"
-            + "\tfilters:\n\t\t"
-            + "\n\t\t".join(f"{k}: {v}" for k, v in filters.items())
+class UniqueLookupError(Exception):
+    def __init__(self, model: Base, objects: Iterable[Base], **filters):
+        error_message = (
+            f"{len(objects)} {model.__name__} were found when 1 was expected,\n"
+            + " filters were:\n\t"
+            + "\n\t".join(f"{k}: {v}" for k, v in filters.items())
         )
+        if len(objects) > 0:
+            error_message = error_message + "\nthe objects were:" + "\n\t".join(objects)
 
-
-class ScenarioAssumptionError(Exception):
-    def __init__(self, missing: Iterable[str] = None, extra: Iterable[str] = None):
-        super().__init__(
-            "the scenario was not correctly given assumptions:\n"
-            + f"\t{missing=}\n"
-            + f"\t{extra=}.",
-        )
+        super().__init__(error_message)

--- a/src/csrs/routes/page_routes/edit.py
+++ b/src/csrs/routes/page_routes/edit.py
@@ -60,7 +60,7 @@ async def page_assumptions_create(
     else:
         try:
             crud.assumptions.create(name=name, kind=kind, detail=detail, db=db)
-        except errors.DuplicateAssumptionError:
+        except errors.DuplicateModelError:
             logger.error("duplicate assumption given, no new object made")
         return RedirectResponse(request.url_for("page_assumptions"), status_code=302)
 
@@ -89,7 +89,7 @@ async def page_scearios_create(
     else:
         try:
             crud.scenarios.create(db=db, **kwargs)
-        except errors.DuplicateAssumptionError:
+        except errors.DuplicateModelError:
             logger.error("duplicate scenario given, no new object made")
         return RedirectResponse(request.url_for("page_scenarios"), status_code=302)
 
@@ -126,7 +126,7 @@ async def page_runs_create(
                 code_version=code_version,
                 detail=detail,
             )
-        except errors.DuplicateAssumptionError:
+        except errors.DuplicateModelError:
             logger.error("duplicate run given, no new object made")
         except AttributeError as e:
             logger.error(f"{e}")
@@ -162,7 +162,7 @@ async def page_paths_create(
                 units=units,
                 detail=detail,
             )
-        except errors.DuplicateAssumptionError:
+        except errors.DuplicateModelError:
             logger.error("duplicate path given, no new object made")
         except AttributeError as e:
             logger.error(f"{e}")

--- a/src/csrs/routes/timeseries.py
+++ b/src/csrs/routes/timeseries.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from .. import crud, schemas
 from ..database import get_db
-from ..errors import LookupUniqueError
+from ..errors import UniqueLookupError
 from ..logger import logger
 
 router = APIRouter(prefix="/timeseries", tags=["Timeseries"])
@@ -24,7 +24,7 @@ async def get_timeseries(
             version=version,
             path=path,
         )
-    except LookupUniqueError:
+    except UniqueLookupError:
         raise HTTPException(
             status_code=404,
             detail=f"couldn't find unique {path=} in database",

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -56,7 +56,7 @@ def test_create_assumption_duplicate():
         db=session,
     )
     crud.assumptions.create(**kwargs)
-    with pytest.raises(errors.DuplicateAssumptionError):
+    with pytest.raises(errors.DuplicateModelError):
         crud.assumptions.create(**kwargs)
 
 

--- a/tests/test_crud_rollback.py
+++ b/tests/test_crud_rollback.py
@@ -1,0 +1,27 @@
+from typing import Callable
+
+from csrs import crud
+
+
+def test_crud_wrapped_with_rollback():
+    unwrapped = list()
+    for module in crud.__all__:
+        for func_name in ("create", "read", "update", "delete"):
+            func: Callable | None = getattr(module, func_name, None)
+            if func is None:  # Module doesn't have that crud operation
+                continue
+            try:
+                func()
+            except NotImplementedError:
+                # Don't enforce wrapping on unimplemented functions
+                continue
+            except TypeError:
+                pass
+            if func_name == func.__name__:
+                unwrapped.append((module, func))
+
+    assert (
+        len(unwrapped) == 0
+    ), "the following functions appear to be unwrapped: " + ", ".join(
+        f"`{m.__name__}.{f.__name__}`" for m, f in unwrapped
+    )


### PR DESCRIPTION
This update re-works the error system so errors are more appropriate, both when no objects are returned, and also when multiple objects are returned when only one is expected.