### PR TITLE
Add library version to the rendered pages

### DIFF
--- a/src/csrs/pages/loader.py
+++ b/src/csrs/pages/loader.py
@@ -1,7 +1,23 @@
 from pathlib import Path
 
+from fastapi import Request
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment
 
-jinja_loader = Jinja2Templates(directory=str(Path(__file__).parent))
+from .. import __version__
+
+
+def library_version_context(request: Request) -> dict[str, str]:
+    v = str(__version__)
+    if __version__ is None:
+        v = "dev"
+    return {"library_version": v}
+
+
+jinja_loader = Jinja2Templates(
+    directory=str(Path(__file__).parent),
+    context_processors=[
+        library_version_context,
+    ],
+)
 ENV: Environment = jinja_loader.env

--- a/src/csrs/pages/templates/base.jinja
+++ b/src/csrs/pages/templates/base.jinja
@@ -113,10 +113,26 @@
                 <div class="col-md-4 d-flex align-items-center">
                     <span class="mb-3 mb-md-0 text-body-secondary">CA Department of Water Resources</span>
                 </div>
-                <ul class="nav col-md-4 justify-content-end list-unstyled d-flex">
-                    <li class="nav-item"><a class="nav-link px-2 text-body-secondary" href="/home"><i class="bi bi-house-fill"></i></a></li>
-                    <li class="nav-item"><a class="nav-link px-2 text-body-secondary" href="/docs"><i class="bi bi-file-earmark-text-fill"></i></a></li>
-                    <li class="nav-item"><a class="nav-link px-2 text-body-secondary" href="https://github.com/CentralValleyModeling/csrs"><i class="bi bi-github"></i></a></li>
+                <ul class="nav col-md-4 justify-content-end align-items-center list-unstyled d-flex">
+                    <li class="nav-item" id="footer-link-home">
+                        <a class="nav-link px-2 text-body-secondary" href="/home">
+                            <i class="bi bi-house-fill"></i>
+                        </a>
+                    </li>
+                    <li class="nav-item" id="footer-link-api-docs">
+                        <a class="nav-link px-2 text-body-secondary" href="/docs">
+                            <i class="bi bi-file-earmark-text-fill"></i>
+                        </a>
+                    </li>
+                    <li class="nav-item" id="footer-link-github">
+                        <a class="nav-link px-2 text-body-secondary" href="https://github.com/CentralValleyModeling/csrs">
+                            <i class="bi bi-github"></i>
+                        </a>
+                    </li>
+                    <li class="nav-item" id="footer-note-library-version">
+                        <span class="mb-3 mb-md-0 text-body-secondary">
+                        <small>csrs-{{library_version}}</small></span>
+                    </li>
                 </ul>
             </footer>
             {% endblock %}


### PR DESCRIPTION
Add a small tag to the bottom of the page to show the library version being used. See below for an example.

![image](https://github.com/user-attachments/assets/fa1ba43d-9fe9-453e-bc59-7fffe39aa9d9)
