### PR TITLE
Feat add default paths by client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 description = "A FastAPI server for CalSim model results and metadata"
 readme = "README.md"
 license = {text = "MIT"}
-version = "0.7.0"
+version = "0.7.1"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]

--- a/src/csrs/clients/local.py
+++ b/src/csrs/clients/local.py
@@ -5,7 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import SingletonThreadPool
 
-from .. import crud, models, schemas
+from .. import crud, enums, models, schemas
 from ..logger import logger
 
 
@@ -186,6 +186,11 @@ class LocalClient:
             detail=detail,
         )
         return crud.paths.create(db=self.session, **obj.model_dump(exclude=("id")))
+
+    def put_standard_paths(self):
+        p: schemas.NamedPath
+        for p in enums.StandardPathsEnum:
+            crud.paths.create(db=self.session, **p.model_dump(exclude=("id")))
 
     def put_timeseries(
         self,

--- a/src/csrs/clients/local.py
+++ b/src/csrs/clients/local.py
@@ -2,11 +2,12 @@ from pathlib import Path
 
 import pandss as pdss
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import SingletonThreadPool
 
 from .. import crud, enums, models, schemas
-from ..logger import logger
+from ..logger import get_logger
 
 
 class LocalClient:
@@ -32,6 +33,7 @@ class LocalClient:
             autoflush=autoflush,
             bind=self.engine,
         )()
+        self.logger = get_logger()
         models.Base.metadata.create_all(bind=self.engine)
 
     def close(self):
@@ -187,10 +189,25 @@ class LocalClient:
         )
         return crud.paths.create(db=self.session, **obj.model_dump(exclude=("id")))
 
-    def put_standard_paths(self):
-        p: schemas.NamedPath
+    def put_standard_paths(self) -> list[schemas.NamedPath]:
+        added = list()
         for p in enums.StandardPathsEnum:
-            crud.paths.create(db=self.session, **p.model_dump(exclude=("id")))
+            try:
+                named = crud.paths.create(
+                    db=self.session, **p.value.model_dump(exclude=("id"))
+                )
+                added.append(named)
+            except IntegrityError as e:
+                self.logger.warning(
+                    f"{type(e).__name__} occurred, likely due to one of the standard "
+                    + "paths already exisitng on the database"
+                )
+            except Exception as e:
+                path = p.value
+                self.logger.error(
+                    f"{type(e).__name__} occurred during path creation, skipping {path}"
+                )
+        return added
 
     def put_timeseries(
         self,
@@ -232,13 +249,15 @@ class LocalClient:
                 try:
                     rtss = list(dss_obj.read_multiple_rts(p.path))
                 except Exception as e:
-                    logger.error(f"{type(e)} when reading {p.path} in {dss}, skipping")
+                    self.logger.error(
+                        f"{type(e)} when reading {p.path} in {dss}, skipping"
+                    )
                     continue
                 if len(rtss) == 0:
-                    logger.warning(f"no datasets match {p.path} in {dss}")
+                    self.logger.warning(f"no datasets match {p.path} in {dss}")
                     continue
                 elif len(rtss) > 1:
-                    logger.warning(
+                    self.logger.warning(
                         f"multiple datasets match {p.path} in {dss}, "
                         + "skipping both to avoid conflicts"
                     )
@@ -250,7 +269,9 @@ class LocalClient:
                     rts=rts,
                 )
                 tss.append(ts)
-        logger.info(f"{len(tss)} Timeseries found from {len(paths)} paths in {dss}")
+        self.logger.info(
+            f"{len(tss)} Timeseries found from {len(paths)} paths in {dss}"
+        )
         return tss
 
     def put_many_timeseries(
@@ -265,6 +286,6 @@ class LocalClient:
                     **ts.model_dump(exclude="id"),
                 )
             except Exception as e:
-                logger.error(f"{type(e)} when adding {ts}, continuing")
+                self.logger.error(f"{type(e)} when adding {ts}, continuing")
             added.append(ts_db)
         return added

--- a/src/csrs/clients/remote.py
+++ b/src/csrs/clients/remote.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandss as pdss
 from httpx import Client
 
-from .. import schemas
+from .. import enums, schemas
 from ..logger import logger
 
 
@@ -422,9 +422,22 @@ class RemoteClient:
             detail=detail,
         )
         url = "/paths"
-        response = self.actor.put(url, json=obj.model_dump(mode="json"))
+        response = self.actor.put(url, json=obj.model_dump(mode="json", exclude=("id")))
         response.raise_for_status()
         return schemas.NamedPath.model_validate(response.json())
+
+    def put_standard_paths(self):
+        p: schemas.NamedPath
+        url = "/paths"
+        for p in enums.StandardPathsEnum:
+            response = self.actor.put(
+                url,
+                json=p.model_dump(
+                    mode="json",
+                    exclude=("id"),
+                ),
+            )
+            response.raise_for_status()
 
     def put_timeseries(
         self,

--- a/src/csrs/logger.py
+++ b/src/csrs/logger.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from functools import cache
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
@@ -45,12 +46,10 @@ def config_logger(cfg: LogConfig | None):
     logger.addHandler(stream_handler)
 
 
+@cache
 def get_logger() -> logging.Logger:
     cfg = LogConfig()
     config_uvicorn_logging(cfg)
     config_logger(cfg)
     logger = logging.getLogger("csrs")
     return logger
-
-
-logger = get_logger()

--- a/src/csrs/logger.py
+++ b/src/csrs/logger.py
@@ -53,3 +53,6 @@ def get_logger() -> logging.Logger:
     config_logger(cfg)
     logger = logging.getLogger("csrs")
     return logger
+
+
+logger = get_logger()

--- a/tests/test_standard_paths.py
+++ b/tests/test_standard_paths.py
@@ -1,0 +1,16 @@
+from csrs import clients, schemas
+
+
+def test_local_standard_paths(client_local: clients.LocalClient):
+    # We only test this one with the local client, since during tests we are only
+    # accessing one local database. The unique constraint on the database would cause
+    # the second test to fail since the first test adds the paths to the database
+    paths = client_local.put_standard_paths()
+    assert len(paths) > 0
+    assert isinstance(paths[0], schemas.NamedPath)
+
+    array = client_local.get_path(
+        path=paths[0].path,
+    )
+    assert len(array) == 1
+    assert array[0].detail == paths[0].detail


### PR DESCRIPTION
Add methods to the client objects to add paths to the database. The default paths are specified in a toml settings file in the `csrs` module.