### PR TITLE
Move reference to variable within try clause

### DIFF
--- a/src/csrs/clients/local.py
+++ b/src/csrs/clients/local.py
@@ -285,7 +285,8 @@ class LocalClient:
                     db=self.session,
                     **ts.model_dump(exclude="id"),
                 )
+                added.append(ts_db)
             except Exception as e:
                 self.logger.error(f"{type(e)} when adding {ts}, continuing")
-            added.append(ts_db)
+
         return added

--- a/src/csrs/clients/remote.py
+++ b/src/csrs/clients/remote.py
@@ -560,7 +560,7 @@ class RemoteClient:
                 response = self.actor.put(url, json=ts.model_dump(mode="json"))
                 response.raise_for_status()
                 ts_db = schemas.Timeseries.model_validate(response.json())
+                added.append(ts_db)
             except Exception as e:
                 self.logger.error(f"{type(e)} when adding {ts}, continuing")
-            added.append(ts_db)
         return added


### PR DESCRIPTION
If error is caught, then the variable might not be defined, which causes an error. Move the reference to 
 to within the ts_db try clause.