### PR TITLE
Bug config access in crud

### DIFF
--- a/src/csrs/config.py
+++ b/src/csrs/config.py
@@ -1,7 +1,6 @@
 import logging
 import logging.handlers
 import sys
-from datetime import datetime
 from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -40,7 +39,6 @@ class AppConfig(LoggedSettings):
 class DatabaseConfig(LoggedSettings):
     source: Path = Path("csrs.db").resolve()
     echo: bool = False
-    epoch: datetime = datetime(1900, 1, 1)
     allow_download: bool = True
     allow_editing_via_forms: bool = False
     model_config = SettingsConfigDict(env_file=".database")

--- a/src/csrs/crud/timeseries.py
+++ b/src/csrs/crud/timeseries.py
@@ -5,21 +5,21 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from .. import models, schemas
-from ..database import db_cfg
 from ..errors import EmptyLookupError, UniqueLookupError
 from . import paths as crud_paths
 from ._common import rollback_on_exception
 
 logger = logging.getLogger(__name__)
+EPOCH = datetime(1900, 1, 1)
 
 
 def date_to_float(date: str) -> float:
-    dt: timedelta = datetime.fromisoformat(date) - db_cfg.epoch
+    dt: timedelta = datetime.fromisoformat(date) - EPOCH
     return dt.total_seconds()
 
 
 def float_to_date(date: float) -> str:
-    dt: datetime = db_cfg.epoch + timedelta(seconds=date)
+    dt: datetime = EPOCH + timedelta(seconds=date)
     return dt.isoformat()
 
 

--- a/src/csrs/database.py
+++ b/src/csrs/database.py
@@ -67,4 +67,5 @@ def get_db():
 ENGINE = make_engine()
 create_recipe_file(engine=ENGINE)
 if not db_cfg.source.exists():
-    init_db()
+    logger.warning("creating empty database because it wasn't found")
+    init_db(ENGINE)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,20 @@
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def test_import():
+    cur_dir = Path(".").resolve()
+    logger.info(f"{cur_dir=}")
+    new_dir = cur_dir / "foo/bar/baz"
+    new_dir.mkdir(parents=True)
+    try:
+        os.chdir(new_dir)
+        import csrs
+    except Exception as e:
+        assert e is None
+    finally:
+        os.chdir(cur_dir)
+        new_dir.rmdir()


### PR DESCRIPTION
When importing the library, the database initialization was incorrectly called because the `csrs.crud.timeseries` module used a value from the database configuration object. This required that `csrs.database` module to be imported, which automatically calls the initialization function if no database exists. This was erroneous, so that configuration value was moved from the `csrs.database` module, to the `csrs.crud.timeseries` module. 

Additional tests were added to check for errors on import in a new directory.